### PR TITLE
Verbose starting OpenERP server

### DIFF
--- a/oorq/tasks.py
+++ b/oorq/tasks.py
@@ -31,7 +31,8 @@ def execute(conf_attrs, dbname, uid, obj, method, *args, **kw):
     start = datetime.now()
     # Disabling logging in OpenERP
     import logging
-    logging.disable(logging.CRITICAL)
+    if not os.getenv('VERBOSE', False):
+        logging.disable(logging.CRITICAL)
     import netsvc
     import tools
     for attr, value in conf_attrs.items():


### PR DESCRIPTION
Use a environment variable `VERBOSE` to see the log when starting OpenERP Server
