### PR TITLE
Fix async mode on split job

### DIFF
--- a/oorq/decorators.py
+++ b/oorq/decorators.py
@@ -95,7 +95,8 @@ class split_job(job):
         def f_job(*args, **kwargs):
             redis_conn = setup_redis_connection()
             current_job = get_current_job()
-            if not args[-1] == token and self.async:
+            async = self.async and AsyncMode.is_async()
+            if not args[-1] == token and async:
                 # Add the token as a last argument
                 args += (token,)
                 # Default arguments


### PR DESCRIPTION
This PR allows to call a function decorated with `@split_job` in sync mode with AsyncMode

```python
@split_job
def function_async():
    something...

with AsyncMode('sync') as asmode:
    function_async()  # This is called in sync mode
```