### PR TITLE
Use cursor signaling

### DIFF
--- a/oorq/autoworker.py
+++ b/oorq/autoworker.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+from __future__ import absolute_import
+from autoworker import AutoWorker as AutoWorkerBase
+from oorq.decorators import log
+from signals import DB_CURSOR_COMMIT, DB_CURSOR_ROLLBACK
+
+
+class AutoWorkerRegister(object):
+
+    AUTOWORKERS_TO_PROCESS = {}
+
+    @classmethod
+    def add_autoworker(cls, transaction_id, worker):
+        cls.AUTOWORKERS_TO_PROCESS.setdefault(transaction_id, [])
+        cls.AUTOWORKERS_TO_PROCESS[transaction_id].append(
+            worker
+        )
+
+    @staticmethod
+    def commit(cursor):
+        transaction_id = id(cursor)
+        workers = AutoWorkerRegister.AUTOWORKERS_TO_PROCESS.pop(
+            transaction_id, []
+        )
+        for worker in workers:
+            log('Spawing worker for queue {} from commit transaction {}'.format(
+                worker.queue.name, transaction_id
+            ))
+            worker.work()
+
+    @staticmethod
+    def rollback(cursor):
+        transaction_id = id(cursor)
+        workers = AutoWorkerRegister.AUTOWORKERS_TO_PROCESS.pop(
+            transaction_id, []
+        )
+        if workers:
+            log('Cancelling {} workers from rollback of transaction {}'.format(
+                len(workers), transaction_id
+            ))
+
+
+DB_CURSOR_COMMIT.connect(AutoWorkerRegister.commit)
+DB_CURSOR_ROLLBACK.connect(AutoWorkerRegister.rollback)
+
+
+class AutoWorker(AutoWorkerBase):
+
+    def work(self, cursor=None):
+        if cursor is None:
+            super(AutoWorker, self).work()
+        else:
+            transaction_id = id(cursor)
+            AutoWorkerRegister.add_autoworker(transaction_id, self)

--- a/oorq/decorators.py
+++ b/oorq/decorators.py
@@ -101,7 +101,7 @@ class job(object):
                     args=job_args,
                     kwargs=job_kwargs,
                     result_ttl=self.result_ttl,
-                    depends_on=current_job
+                    depends_on=current_job,
                     at_front=self.at_front
                 )
                 set_hash_job(job)

--- a/oorq/decorators.py
+++ b/oorq/decorators.py
@@ -102,6 +102,7 @@ class job(object):
                         execute,
                         args=job_args,
                         kwargs=job_kwargs,
+                        timeout=self.timeout,
                         result_ttl=self.result_ttl,
                         depends_on=current_job,
                     )

--- a/oorq/tests/test_oorq/partner.py
+++ b/oorq/tests/test_oorq/partner.py
@@ -25,6 +25,10 @@ class ResPartner(osv.osv):
         self.dependency_job(cursor, uid, ids, vals, context=context)
         return True
 
+    def test_no_enqueue_on_rollback(self, cursor, uid, ids, vals, context=None):
+        self.write_async(cursor, uid, ids, vals, context)
+        raise osv.except_osv('Error', 'Test error!')
+
     @job(async=True, queue='default')
     def write_async(self, cr, user, ids, vals, context=None):
         #TODO: process before updating resource

--- a/oorq/tests/test_oorq/partner.py
+++ b/oorq/tests/test_oorq/partner.py
@@ -23,13 +23,17 @@ class ResPartner(osv.osv):
 
     def test_dependency_job(self, cursor, uid, ids, vals, context=None):
         self.dependency_job(cursor, uid, ids, vals, context=context)
+        return
+
+    def test_dependency_job_on_commit(self, cursor, uid, ids, vals, context=None):
+        self.dependency_job_on_commit(cursor, uid, ids, vals, context=context)
         return True
 
     def test_no_enqueue_on_rollback(self, cursor, uid, ids, vals, context=None):
         self.write_async(cursor, uid, ids, vals, context)
         raise osv.except_osv('Error', 'Test error!')
 
-    @job(async=True, queue='default')
+    @job(async=True, queue='default', on_commit=True)
     def write_async(self, cr, user, ids, vals, context=None):
         #TODO: process before updating resource
         res = super(ResPartner, self).write(cr, user, ids, vals, context)
@@ -51,6 +55,15 @@ class ResPartner(osv.osv):
 
     @job(queue='dependency')
     def dependency_job(self, cursor, uid, ids, vals, context=None):
+        print "First job"
+        import time
+        self.write_async(cursor, uid, ids, vals, context=context)
+        print "I'm working and not affected for the subjob"
+        time.sleep(10)
+        return True
+
+    @job(queue='dependency', on_commit=True)
+    def dependency_job_on_commit(self, cursor, uid, ids, vals, context=None):
         print "First job"
         import time
         self.write_async(cursor, uid, ids, vals, context=context)


### PR DESCRIPTION
Now is possible to enqueue jobs when the transaction is commited, using a new parameter on `job` definition `on_commit=True`. e.g.:

```python
@job(queue='high', on_commit=True)
def hard_job_in_the_night(cursor, uid, ids, context=None):
    ...
```

Default behavior is `on_commit=False` to maintain backward compatibility

Needs https://github.com/gisce/erp/pull/6412

As commented in https://github.com/gisce/oorq/pull/74#issuecomment-383154672 we have created and extension of `AutoWorker` to work with the new cursor signaling system.

:warning: **NOTE**: If some jobs are executed in AutoWorker and the job is configured `on_commit` we should use our version of AutoWorker

```python
from autoworker import AutoWorker
...
# And then
aw = AutoWorker(queue='make_invoices', default_result_ttl=24 * 3600)
aw.work()
```

to:

```python
from oorq.autoworker import AutoWorker
...
# And then
aw = AutoWorker(queue='make_invoices', default_result_ttl=24 * 3600)
aw.work(cursor)
```

:information_source: cursor is the cursor we want to bind the start of autoworkers

/cc @rchamorro 