### PR TITLE
Fix version to work with current oorq version

### DIFF
--- a/oorq/requirements.txt
+++ b/oorq/requirements.txt
@@ -1,5 +1,5 @@
-rq>=0.9.2,<1.0
 redis<3.0
+rq>=0.9.2,<0.13
 rq-dashboard
 osconf
 autoworker

--- a/oorq/requirements.txt
+++ b/oorq/requirements.txt
@@ -1,4 +1,4 @@
-rq>=0.9.2
+rq>=0.9.2,<1.0
 rq-dashboard
 osconf
 autoworker

--- a/tests/tests_5_requirements.txt
+++ b/tests/tests_5_requirements.txt
@@ -1,7 +1,7 @@
 Python-Chart
 egenix-mx-base
 lxml
-psycopg2
+psycopg2<2.8
 pydot
 pyparsing
 reportlab<3


### PR DESCRIPTION
New API from RQ (https://github.com/rq/rq/blob/master/CHANGES.md#10-2019-04-06) isn't compatible with our current version.