### PR TITLE
[FIX] Update code for new rq version, 1.0

### DIFF
--- a/oorq/bin/requeue_failed.py
+++ b/oorq/bin/requeue_failed.py
@@ -15,7 +15,7 @@ use_connection(redis_conn)
 fq = FailedJobRegistry()
 pq = Queue(name=PERMANENT_FAILED)
 
-for job in pq.failed_job_registry:
+for job in fq.failed_job_registry:
     job.meta.setdefault('attempts', 0)
     if job.meta['attempts'] > MAX_ATTEMPTS:
         print "Job %s %s attempts. MAX ATTEMPTS %s limit exceeded on %s" % (

--- a/oorq/bin/requeue_failed.py
+++ b/oorq/bin/requeue_failed.py
@@ -2,7 +2,8 @@
 import sys
 import times
 from redis import from_url
-from rq import use_connection, get_failed_queue, requeue_job, Queue
+from rq import use_connection, requeue_job, Queue
+from rq.registry import FailedJobRegistry
 
 INTERVAL = 7200  # Seconds
 MAX_ATTEMPTS = 5
@@ -11,10 +12,10 @@ PERMANENT_FAILED = 'permanent'
 redis_conn = from_url(sys.argv[1])
 use_connection(redis_conn)
 
-fq = get_failed_queue()
+fq = FailedJobRegistry()
 pq = Queue(name=PERMANENT_FAILED)
 
-for job in fq.jobs:
+for job in pq.failed_job_registry:
     job.meta.setdefault('attempts', 0)
     if job.meta['attempts'] > MAX_ATTEMPTS:
         print "Job %s %s attempts. MAX ATTEMPTS %s limit exceeded on %s" % (
@@ -23,7 +24,7 @@ for job in fq.jobs:
         print job.description
         print job.exc_info
         print
-        fq.remove(job)
+        fq.remove(job) # mirar perque potser job ara es diferent
         pq.enqueue_job(job)
         print "Moved to %s queue" % PERMANENT_FAILED
     else:

--- a/oorq/tasks.py
+++ b/oorq/tasks.py
@@ -7,7 +7,8 @@ import traceback
 from datetime import datetime
 from math import ceil
 
-from rq import get_failed_queue, get_current_job
+from rq import get_current_job
+from rq.registry import FailedJobRegistry
 from rq.job import Job
 from .exceptions import *
 from .oorq import StoredJobsPool, setup_redis_connection
@@ -113,7 +114,7 @@ def isolated_execute(conf_attrs, dbname, uid, obj, method, *args, **kw):
             failed_ids.append(exe_id)
     if failed_ids:
         # Create a new job and enqueue to failed queue
-        fq = get_failed_queue()
+        fq = FailedJobRegistry()
         args[0] = failed_ids
         exc_info = ''.join(traceback.format_exception(*sys.exc_info()))
         job_args = (conf_attrs, dbname, uid, obj, method) + tuple(args)


### PR DESCRIPTION
In the new version of rq, the function `get_failed_queue` has been deprecated.
This is a **non-tested update** of the code following the rq changelog of the v1.0 version.

https://github.com/rq/rq/blob/master/CHANGES.md

https://github.com/rq/rq/pull/1009/files?file-filters%5B%5D=.md&file-filters%5B%5D=.py#diff-97aa2f84df68bff74ea8272c7a176f99