### PR TITLE
Allow use split_jobs without on_commit behaviour

### DIFF
--- a/oorq/decorators.py
+++ b/oorq/decorators.py
@@ -190,41 +190,40 @@ class split_job(job):
                         conf_attrs, dbname, uid, osv_object, fname
                     ] + args[3:]
                     job_kwargs = kwargs
+                    at_front = self.at_front
                     if self.on_commit:
                         job = Job.create(
                             task,
-                            depends_on=current_job,
-                            result_ttl=self.result_ttl,
                             args=job_args,
-                            kwargs=job_kwargs
+                            kwargs=job_kwargs,
+                            timeout=self.timeout,
+                            result_ttl=self.result_ttl,
+                            depends_on=current_job
                         )
-                        set_hash_job(job)
                         transaction_id = id(cursor)
-                        ProcessJobs.add_job(transaction_id, job, q)
+                        ProcessJobs.add_job(transaction_id, job, q, at_front)
                         log('Created split job (%s/%s) on queue %s in %s mode '
                             '(id:%s): [%s] pool(%s).%s%s '
                             '(waiting to commit/rollback %s)' % (
                                 idx + 1, len(chunks), q.name, mode, job.id,
                                 dbname, osv_object, fname, tuple(args[2:]),
                                 transaction_id
-                            )
-                        )
+                        ))
                     else:
                         job = q.enqueue(
                             task,
                             depends_on=current_job,
                             result_ttl=self.result_ttl,
                             args=job_args,
-                            kwargs=job_kwargs
+                            kwargs=job_kwargs,
+                            at_front=at_front
                         )
-                        set_hash_job(job)
                         log('Created split job (%s/%s) on queue %s in %s mode '
                             '(id:%s): [%s] pool(%s).%s%s ' % (
                                 idx + 1, len(chunks), q.name, mode, job.id,
                                 dbname, osv_object, fname, tuple(args[2:])
-                            )
-                        )
-
+                        ))
+                    set_hash_job(job)
                     jobs.append(job)
                 return jobs
             else:


### PR DESCRIPTION
The PR https://github.com/gisce/oorq/pull/74 added support for enqueue jobs when transaction is closed. **This behaviour was allways activated for split_jobs despite the value of `self.on_commit`**.
This PR fixes this behaviour consulting the value of `self.on_commit` to chose if the Job is queued or created waiting to transaction.