### PR TITLE
Add requeue feature

### DIFF
--- a/oorq/bin/requeue_failed.py
+++ b/oorq/bin/requeue_failed.py
@@ -22,6 +22,8 @@ for queue in all_queues:
     fq = FailedJobRegistry(queue.name)
     for job_id in fq.get_job_ids():
         job = Job.fetch(job_id)
+        if not job.meta.get('requeue', True):
+            continue
         job.meta.setdefault('attempts', 0)
         if job.meta['attempts'] > MAX_ATTEMPTS:
             print("Job %s %s attempts. MAX ATTEMPTS %s limit exceeded on %s" % (

--- a/oorq/decorators.py
+++ b/oorq/decorators.py
@@ -66,6 +66,7 @@ class job(object):
         self.result_ttl = None
         self.at_front = False
         self.on_commit = False
+        self.requeue = True
         # Assign all the arguments to attributes
         config = config_from_environment('OORQ', **kwargs)
         for arg, value in config.items():
@@ -124,6 +125,8 @@ class job(object):
                     )
                     log('Enqueued job (id:%s) on queue %s: [%s] pool(%s).%s%s'
                         % (job.id, q.name, dbname, osv_object, fname, args[2:]))
+                job.meta['requeue'] = self.requeue
+                job.save()
                 set_hash_job(job)
                 return job
             else:
@@ -223,6 +226,8 @@ class split_job(job):
                                 idx + 1, len(chunks), q.name, mode, job.id,
                                 dbname, osv_object, fname, tuple(args[2:])
                         ))
+                    job.meta['requeue'] = self.requeue
+                    job.save()
                     set_hash_job(job)
                     jobs.append(job)
                 return jobs


### PR DESCRIPTION
- Now we can decide if we want to requeue or not adding `requeue` to `@job` **default is `True`** decorator. eg.

## Tasks
- [x] Skip requeue in requeue script
- [ ] Remove job from failed queue


## Example

```python
@job(queue='foo', requeue=False)
def foobar():
    pass
```