### PR TITLE
Recover logs info on async mode

### DIFF
--- a/oorq/tasks.py
+++ b/oorq/tasks.py
@@ -57,7 +57,10 @@ def execute(conf_attrs, dbname, uid, obj, method, *args, **kw):
     osv_ = osv.osv.osv_pool()
     db, pool = pooler.get_db_and_pool(dbname)
     logging.disable(0)
-    logger = logging.getLogger(__name__)
+    if not pool._ready and not AsyncMode.is_async():
+        logger = logging.getLogger(__name__)
+    else:
+        logger = logging.getLogger()
     logger.handlers = []
     log_level = tools.config['log_level']
     worker_log_level = os.getenv('LOG', False)


### PR DESCRIPTION
Try to recover the initial `logging Logger` that execute the `oorq` task
It seems that get a logger with __name__ "hijacks the principal"

This following commit fixes running tasks in sync mode when pool is not ready

https://github.com/gisce/oorq/pull/85/commits/1a882b3918c7cbadeeb51035aa496934fc6d5753

- Check the pool and sync mode to set logger