### PR TITLE
Actualizar version rq vara evitar dejar procesos zombies (1.1.0 -> 1.3.0) (maxima soportada por py 2.7)

### DIFF
--- a/oorq/requirements.txt
+++ b/oorq/requirements.txt
@@ -1,4 +1,4 @@
-rq==1.1.0
+rq==1.3.0
 rq-dashboard
 osconf
 autoworker


### PR DESCRIPTION
[RQ v1.3.0 chlog](https://github.com/rq/rq/releases/tag/v1.3.0)
[RQ v1.2.2 chlog](https://github.com/rq/rq/releases/tag/v1.2.2)
[RQ v1.2.1 chlog](https://github.com/rq/rq/releases/tag/v1.2.1)

El que mas nos interesa es la vesion 1.3.0 para evitar que los autoworkers dejen procesos zombies inmatables a menos que se mate la instancia del erp que los origino.

`Fixes an issue that may cause zombie processes`

![image](https://user-images.githubusercontent.com/15796004/154099674-1e87d080-420c-4515-8f19-abe5029f5501.png)
