### PR TITLE
FIX para función de búsqueda de oorq.queue

### DIFF
--- a/oorq/oorq.py
+++ b/oorq/oorq.py
@@ -361,7 +361,7 @@ class OorqQueue(osv.osv):
                 elif op in ['in', 'not in']:
                     res = [queue for queue in res if (getattr(queue, 'name') in value) != ('not' in op)]
 
-        res = res[offset:]
+        res = res[int(offset):]
         if limit:
             res = res[:limit]
 

--- a/oorq/oorq.py
+++ b/oorq/oorq.py
@@ -363,7 +363,7 @@ class OorqQueue(osv.osv):
 
         res = res[int(offset):]
         if limit:
-            res = res[:limit]
+            res = res[:int(limit)]
 
         if count:
             return len(res)


### PR DESCRIPTION
## Error
![imatge](https://github.com/gisce/oorq/assets/36483261/90ed7829-48d9-4f07-a431-f6af7d1381ae)

- Cuando el GTK-Client llama la función de búsqueda, pasa los parámetros `offset` y `limit` como `float`.

## Solución
- Estos parámetros deben ser casteados a `int`.
![imatge](https://github.com/gisce/oorq/assets/36483261/7979989d-2ac8-4903-b213-402cb4c79897)
