### PR TITLE
Fix requirement MarkupSafe<=2.0.1

### DIFF
--- a/oorq/requirements.txt
+++ b/oorq/requirements.txt
@@ -3,3 +3,4 @@ rq-dashboard
 osconf
 autoworker
 six
+MarkupSafe<=2.0.1


### PR DESCRIPTION
On a clean install MarkupSafe last version is installed due last release of flask 3.0.0 https://pypi.org/project/Flask/3.0.0/
+ Jinja2>=3.1.2 dep

jinja 3.1.2 dependencies = ["MarkupSafe>=2.0"] https://github.com/pallets/jinja/blob/main/pyproject.toml

Due MarkupSafe 2.1.0:

```bash
File "/home/ci_replicante/ci_runners/replicante2/_work/erp/erp/erp/server/bin/addons/oorq/__init__.py", line 17, in <module>
    from . import serializers
  File "/home/ci_replicante/ci_runners/replicante2/_work/erp/erp/erp/server/bin/addons/oorq/serializers.py", line 6, in <module>
    from flask import current_app
  File "/home/ci_replicante/.pyenv/versions/3.11.4/envs/1697523048/lib/python3.11/site-packages/flask/__init__.py", line 14, in <module>
    from jinja2 import escape
  File "/home/ci_replicante/.pyenv/versions/3.11.4/envs/1697523048/lib/python3.11/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/home/ci_replicante/.pyenv/versions/3.11.4/envs/16975230[48](https://github.com/gisce/erp/actions/runs/6543226622/job/17767462072?pr=18271#step:9:49)/lib/python3.11/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/home/ci_replicante/.pyenv/versions/3.11.4/envs/1697523048/lib/python3.11/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ci_replicante/.pyenv/versions/3.11.4/envs/1697[52](https://github.com/gisce/erp/actions/runs/6543226622/job/17767462072?pr=18271#step:9:53)3048/lib/python3.11/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/home/ci_replicante/.pyenv/versions/3.11.4/envs/1697523048/lib/python3.11/site-packages/markupsafe/__init__.py)
```