### PR TITLE
Pubsub Subscribe to queue channel

### DIFF
--- a/oorq/worker.py
+++ b/oorq/worker.py
@@ -23,7 +23,18 @@ class Worker(RQWorker):
         self.log.propagate = False
         try:
             from service.pubsub import PubSub
-            PubSub.connect('{}.worker'.format(config['db_name']))
+            if hasattr(tools.config, 'pubsub_subscriptions'):
+                subscriptions = (
+                    config.pubsub_subscriptions +
+                    ['{}.worker'.format(config['db_name'])] +
+                    [
+                        '{}.worker.{}'.format(config['db_name'], _q.name)
+                        for _q in self.queues
+                    ]
+                )
+                PubSub.connect(subscriptions)
+            else:
+                PubSub.connect('{}.worker'.format(config['db_name']))
         except ImportError:
             pass
 


### PR DESCRIPTION
Subscribe workers to queues channels with pattern {db_name}.worker.{queue_name}

![image](https://github.com/gisce/oorq/assets/15796004/a17c6753-2f9f-47aa-9b5e-d0ea6c0413ee)

![image](https://github.com/gisce/oorq/assets/15796004/82363468-cca4-476d-b779-e592f62893b0)

Needs https://github.com/gisce/erp/pull/19469 to use the feature but is not required to work