### PR TITLE
Use webservice tracker in oorq

### DIFF
--- a/oorq/tasks.py
+++ b/oorq/tasks.py
@@ -83,6 +83,7 @@ def execute(conf_attrs, dbname, uid, obj, method, *args, **kw):
     import sql_db
     from ctx import _context_stack
     from service.security import Sudo
+    from tools.service_utils import WebServiceTracker
     try:
         from tools.service_utils import SimpleGlobalUUIDGenerator
     except ImportError:
@@ -111,8 +112,9 @@ def execute(conf_attrs, dbname, uid, obj, method, *args, **kw):
     with context:
         with SimpleGlobalUUIDGenerator() as _uuid:
             _uuid = _uuid if not isinstance(_uuid, DummySudo) else None
-            with SentryCatch(_uuid=_uuid, obj=obj, method=method):
-                res = osv_.execute(dbname, uid, obj, method, *args, **kw)
+            with WebServiceTracker(_uuid=_uuid, uid=uid, obj=obj, method=method, db=db) as wst:
+                with SentryCatch(_uuid=_uuid, obj=obj, method=method):
+                    res = osv_.execute(dbname, uid, obj, method, *args, **kw)
 
     _context_stack.pop()
     logger.info('Time elapsed: %s' % (datetime.now() - start))
@@ -138,6 +140,7 @@ def isolated_execute(conf_attrs, dbname, uid, obj, method, *args, **kw):
     import report
     import service
     from service.security import Sudo
+    from tools.service_utils import WebServiceTracker
     import sql_db
     try:
         from tools.service_utils import SimpleGlobalUUIDGenerator
@@ -166,8 +169,9 @@ def isolated_execute(conf_attrs, dbname, uid, obj, method, *args, **kw):
             with context:
                 with SimpleGlobalUUIDGenerator() as _uuid:
                     _uuid = _uuid if not isinstance(_uuid, DummySudo) else None
-                    with SentryCatch(_uuid=_uuid, obj=obj, method=method):
-                        res = osv_.execute(dbname, uid, obj, method, *args, **kw)
+                    with WebServiceTracker(_uuid=_uuid, uid=uid, obj=obj, method=method) as wst:
+                        with SentryCatch(_uuid=_uuid, obj=obj, method=method):
+                            res = osv_.execute(dbname, uid, obj, method, *args, **kw)
             all_res.append(res)
         except:
             logger.error('Executing id %s failed' % exe_id)

--- a/oorq/tasks.py
+++ b/oorq/tasks.py
@@ -169,7 +169,7 @@ def isolated_execute(conf_attrs, dbname, uid, obj, method, *args, **kw):
             with context:
                 with SimpleGlobalUUIDGenerator() as _uuid:
                     _uuid = _uuid if not isinstance(_uuid, DummySudo) else None
-                    with WebServiceTracker(_uuid=_uuid, uid=uid, obj=obj, method=method) as wst:
+                    with WebServiceTracker(_uuid=_uuid, uid=uid, obj=obj, method=method):
                         with SentryCatch(_uuid=_uuid, obj=obj, method=method):
                             res = osv_.execute(dbname, uid, obj, method, *args, **kw)
             all_res.append(res)

--- a/oorq/tasks.py
+++ b/oorq/tasks.py
@@ -112,7 +112,7 @@ def execute(conf_attrs, dbname, uid, obj, method, *args, **kw):
     with context:
         with SimpleGlobalUUIDGenerator() as _uuid:
             _uuid = _uuid if not isinstance(_uuid, DummySudo) else None
-            with WebServiceTracker(_uuid=_uuid, uid=uid, obj=obj, method=method, db=db) as wst:
+            with WebServiceTracker(_uuid=_uuid, uid=uid, obj=obj, method=method, db=db):
                 with SentryCatch(_uuid=_uuid, obj=obj, method=method):
                     res = osv_.execute(dbname, uid, obj, method, *args, **kw)
 


### PR DESCRIPTION
This pull request introduces the `WebServiceTracker` utility to enhance tracking and monitoring during task execution in the `oorq/tasks.py` file. The changes integrate `WebServiceTracker` into both the `execute` and `isolated_execute` methods, ensuring better observability and contextual tracking.

Enhancements to task execution tracking:

* [`oorq/tasks.py`](diffhunk://#diff-fe0e25d22d576dbec87ba198141c64b8bc6f478e2e1cff950cdc3896d3f08e5dR86): Imported `WebServiceTracker` from `tools.service_utils` to use it within the `execute` and `isolated_execute` methods. [[1]](diffhunk://#diff-fe0e25d22d576dbec87ba198141c64b8bc6f478e2e1cff950cdc3896d3f08e5dR86) [[2]](diffhunk://#diff-fe0e25d22d576dbec87ba198141c64b8bc6f478e2e1cff950cdc3896d3f08e5dR143)
* [`oorq/tasks.py`](diffhunk://#diff-fe0e25d22d576dbec87ba198141c64b8bc6f478e2e1cff950cdc3896d3f08e5dR115): Added a `WebServiceTracker` context manager to the `execute` method, passing `_uuid`, `uid`, `obj`, `method`, and `db` for improved tracking during execution.
* [`oorq/tasks.py`](diffhunk://#diff-fe0e25d22d576dbec87ba198141c64b8bc6f478e2e1cff950cdc3896d3f08e5dR172): Added a `WebServiceTracker` context manager to the `isolated_execute` method, passing `_uuid`, `uid`, `obj`, and `method` for enhanced monitoring during isolated execution.