### PR TITLE
Add autorefresh fields

### DIFF
--- a/oorq/migrations/5.0.1.32.0/post-0001_reload_view_autorefresh_fields.py
+++ b/oorq/migrations/5.0.1.32.0/post-0001_reload_view_autorefresh_fields.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+import logging
+from tools import config
+from oopgrade.oopgrade import MigrationHelper
+
+
+logger = logging.getLogger('openerp.migration.' + __name__)
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+    mg = MigrationHelper(cursor, 'oorq')
+    mg.update_xml_records(
+        'oorq_view.xml',
+        update_record_ids=[
+            'view_oorq_worker_tree',
+            'view_oorq_queue_tree',
+            'view_oorq_registry_tree',
+            'view_oorq_job_form',
+            'view_oorq_job_tree',
+            'view_oorq_jobs_group_form',
+            'view_oorq_jobs_group_tree',
+        ]
+    )
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/oorq/oorq_view.xml
+++ b/oorq/oorq_view.xml
@@ -14,13 +14,13 @@
                     <field name="name"/>
                     <field name="wclass"/>
                     <field name="queues"/>
-                    <field name="state"/>
-                    <field name="total_working_time"/>
-                    <field name="successful_job_count"/>
-                    <field name="failed_job_count"/>
-                    <field name="birth_date"/>
-                    <field name="last_heartbeat"/>
-                    <field name="current_job_id"/>
+                    <field name="state" autorefresh="1"/>
+                    <field name="total_working_time" autorefresh="1"/>
+                    <field name="successful_job_count" autorefresh="1"/>
+                    <field name="failed_job_count" autorefresh="1"/>
+                    <field name="birth_date" autorefresh="1"/>
+                    <field name="last_heartbeat" autorefresh="1"/>
+                    <field name="current_job_id" autorefresh="1"/>
                 </tree>
             </field>
         </record>
@@ -42,8 +42,8 @@
             <field name="arch" type="xml">
                 <tree string="Active Queues">
                     <field name="name"/>
-                    <field name="n_jobs"/>
-                    <field name="is_empty"/>
+                    <field name="n_jobs" autorefresh="1"/>
+                    <field name="is_empty" autorefresh="1"/>
                 </tree>
             </field>
         </record>
@@ -65,7 +65,7 @@
             <field name="arch" type="xml">
                 <tree string="Registry">
                     <field name="name"/>
-                    <field name="n_jobs"/>
+                    <field name="n_jobs" autorefresh="1"/>
                     <field name="queue"/>
                 </tree>
             </field>
@@ -163,22 +163,22 @@
                     <group colspan="2" col="2">
                         <field name="queue"/>
                         <field name="origin"/>
-                        <field name="status"/>
+                        <field name="status" autorefresh="1"/>
                     </group>
                     <group col="2" colspan="2">
                         <field name="created_at"/>
                         <field name="enqueued_at"/>
-                        <field name="ended_at"/>
+                        <field name="ended_at" autorefresh="1"/>
                     </group>
                     <notebook colspan="4">
                         <page string="Description">
                             <field name="description" nolabel="1" colspan="4"/>
                         </page>
                         <page string="Result">
-                            <field name="result" nolabel="1" colspan="4"/>
+                            <field name="result" nolabel="1" colspan="4" autorefresh="1"/>
                         </page>
                         <page string="Exception info">
-                            <field name="exc_info" nolabel="1" colspan="4"/>
+                            <field name="exc_info" nolabel="1" colspan="4" autorefresh="1"/>
                         </page>
                     </notebook>
                     <group string="Actions" colspan="4" col="4">
@@ -195,14 +195,14 @@
             <field name="arch" type="xml">
                 <tree string="Active jobs">
                     <field name="jid"/>
-                    <field name="status"/>
+                    <field name="status" autorefresh="1"/>
                     <field name="queue"/>
                     <field name="created_at"/>
                     <field name="enqueued_at"/>
-                    <field name="ended_at"/>
+                    <field name="ended_at" autorefresh="1"/>
                     <field name="origin"/>
-                    <field name="result"/>
-                    <field name="exc_info"/>
+                    <field name="result" autorefresh="1"/>
+                    <field name="exc_info" autorefresh="1"/>
                     <field name="description"/>
                 </tree>
             </field>
@@ -268,11 +268,11 @@
             <field name="arch" type="xml">
                 <form string="Jobs group">
                     <field name="name" colspan="4" select="1"/>
-                    <field name="progress" colspan="4" widget="progressbar"/>
+                    <field name="progress" colspan="4" widget="progressbar" autorefresh="1"/>
                     <field name="start" select="1"/>
-                    <field name="end" select="1"/>
+                    <field name="end" select="1" autorefresh="1"/>
                     <field name="num_jobs" />
-                    <field name="active" select="1"/>
+                    <field name="active" select="1" autorefresh="1"/>
                     <field name="user_id" select="1"/>
                 </form>
             </field>
@@ -284,13 +284,13 @@
             <field name="arch" type="xml">
                 <tree string="Jobs groups">
                     <field name="name" colspan="4" select="1"/>
-                    <field name="progress" colspan="4" widget="progressbar"/>
-                    <field name="start"/>
-                    <field name="end"/>
+                    <field name="progress" colspan="4" widget="progressbar" autorefresh="1"/>
+                    <field name="start" autorefresh="1"/>
+                    <field name="end" autorefresh="1"/>
                     <field name="num_jobs" />
-                    <field name="num_failed_jobs" />
-                    <field name="num_success_jobs" />
-                    <field name="active"/>
+                    <field name="num_failed_jobs" autorefresh="1"/>
+                    <field name="num_success_jobs" autorefresh="1"/>
+                    <field name="active" autorefresh="1"/>
                     <field name="user_id"/>
                 </tree>
             </field>


### PR DESCRIPTION
This pull request introduces a migration script and updates to the `oorq_view.xml` file to enable automatic refreshing of specific fields in various views. The changes aim to improve the user experience by ensuring real-time updates for critical data displayed in the UI.

### Migration Script Addition:
* [`oorq/migrations/5.0.1.32.0/post-0001_reload_view_autorefresh_fields.py`](diffhunk://#diff-30de8019b5faf89c00701ad8a93f0dab2bbe37544aa90afdc159fef8aa33faa5R1-R32): Added a migration script that reloads views and applies `autorefresh` attributes to certain fields in `oorq_view.xml`. The script uses the `MigrationHelper` class to update XML records for multiple view IDs.

### Updates to Views:
#### Worker Tree and Queue Views:
* [`oorq/oorq_view.xml`](diffhunk://#diff-15b77eb057d25da045d4e351d1d7add0a031ecc1b354436402a7e9deadd8fc6dL17-R23): Added `autorefresh="1"` to fields such as `state`, `total_working_time`, `successful_job_count`, and others in the worker tree and queue views. This ensures these fields refresh automatically. [[1]](diffhunk://#diff-15b77eb057d25da045d4e351d1d7add0a031ecc1b354436402a7e9deadd8fc6dL17-R23) [[2]](diffhunk://#diff-15b77eb057d25da045d4e351d1d7add0a031ecc1b354436402a7e9deadd8fc6dL45-R46)

#### Registry and Active Jobs Views:
* [`oorq/oorq_view.xml`](diffhunk://#diff-15b77eb057d25da045d4e351d1d7add0a031ecc1b354436402a7e9deadd8fc6dL68-R68): Enabled `autorefresh="1"` for fields like `n_jobs`, `status`, `ended_at`, `result`, and `exc_info` in the registry and active jobs views. This allows these fields to update dynamically. [[1]](diffhunk://#diff-15b77eb057d25da045d4e351d1d7add0a031ecc1b354436402a7e9deadd8fc6dL68-R68) [[2]](diffhunk://#diff-15b77eb057d25da045d4e351d1d7add0a031ecc1b354436402a7e9deadd8fc6dL198-R205)

#### Jobs Group Views:
* [`oorq/oorq_view.xml`](diffhunk://#diff-15b77eb057d25da045d4e351d1d7add0a031ecc1b354436402a7e9deadd8fc6dL271-R275): Added `autorefresh="1"` to fields such as `progress`, `start`, `end`, `num_failed_jobs`, and others in the jobs group form and tree views to ensure real-time updates. [[1]](diffhunk://#diff-15b77eb057d25da045d4e351d1d7add0a031ecc1b354436402a7e9deadd8fc6dL271-R275) [[2]](diffhunk://#diff-15b77eb057d25da045d4e351d1d7add0a031ecc1b354436402a7e9deadd8fc6dL287-R293)