### PR TITLE
Reducir memoria en jobs on_commit

### DIFF
--- a/oorq/decorators.py
+++ b/oorq/decorators.py
@@ -36,10 +36,10 @@ class ProcessJobs(object):
     JOBS_TO_PROCESS = {}
 
     @classmethod
-    def add_job(cls, transaction_id, job, queue, at_font=False):
+    def add_job(cls, transaction_id, job, queue, at_front=False):
         cls.JOBS_TO_PROCESS.setdefault(transaction_id, [])
         cls.JOBS_TO_PROCESS[transaction_id].append(
-            JobToProcess(job.id, queue.name, at_font)
+            JobToProcess(job.id, queue.name, at_front)
         )
 
     @staticmethod
@@ -55,18 +55,32 @@ class ProcessJobs(object):
     def commit(cursor):
         transaction_id = id(cursor)
         redis_conn = setup_redis_connection()
-        jobs = [
-            j for j in ProcessJobs.JOBS_TO_PROCESS.pop(transaction_id, [])
-            if isinstance(j, JobToProcess)
-        ]
-        for job_id, queue_name, at_front in jobs:
-            job = Job.fetch(job_id, connection=redis_conn)
+        pending_jobs = ProcessJobs.JOBS_TO_PROCESS.get(transaction_id, [])
+        index = 0
+        while index < len(pending_jobs):
+            pending_job = pending_jobs[index]
+            if not isinstance(pending_job, JobToProcess):
+                del pending_jobs[index]
+                continue
+
+            job_id, queue_name, at_front = pending_job
+            try:
+                job = Job.fetch(job_id, connection=redis_conn)
+            except NoSuchJobError:
+                log('Job {} was not found during commit of transaction {}; '
+                    'skipping enqueue'.format(job_id, transaction_id),
+                    netsvc.LOG_WARNING)
+                del pending_jobs[index]
+                continue
+
             queue = Queue(queue_name, connection=redis_conn)
             queue.enqueue_job(job, at_front=at_front)
             log('Enqueued job {} to queue {} from commit transaction {}'.format(
                 job.id, queue.name, transaction_id
             ))
-        if transaction_id in ProcessJobs.JOBS_TO_PROCESS:
+            del pending_jobs[index]
+
+        if not pending_jobs and transaction_id in ProcessJobs.JOBS_TO_PROCESS:
             del ProcessJobs.JOBS_TO_PROCESS[transaction_id]
 
     @staticmethod
@@ -175,12 +189,6 @@ class job(object):
                         depends_on=current_job,
                     )
                     transaction_id = id(cursor)
-                    ProcessJobs.add_job(transaction_id, job, q, self.at_front)
-                    log('Created job (id:%s) for queue %s: [%s] pool(%s).%s%s '
-                        '(waiting to commit/rollback %s)' % (
-                            job.id, q.name, dbname, osv_object, fname, args[2:],
-                            transaction_id
-                        ))
                 else:
                     job = q.enqueue(
                         execute,
@@ -195,6 +203,13 @@ class job(object):
                 job.meta['requeue'] = self.requeue
                 job.save()
                 set_hash_job(job)
+                if self.on_commit and async_mode:
+                    ProcessJobs.add_job(transaction_id, job, q, self.at_front)
+                    log('Created job (id:%s) for queue %s: [%s] pool(%s).%s%s '
+                        '(waiting to commit/rollback %s)' % (
+                            job.id, q.name, dbname, osv_object, fname, args[2:],
+                            transaction_id
+                        ))
                 return job
             else:
                 # Remove the token
@@ -277,14 +292,6 @@ class split_job(job):
                             depends_on=current_job
                         )
                         transaction_id = id(cursor)
-                        ProcessJobs.add_job(transaction_id, job, q, at_front)
-                        log('Created split job (%s/%s) on queue %s in %s mode '
-                            '(id:%s): [%s] pool(%s).%s%s '
-                            '(waiting to commit/rollback %s)' % (
-                                idx + 1, len(chunks), q.name, mode, job.id,
-                                dbname, osv_object, fname, tuple(args[2:]),
-                                transaction_id
-                        ))
                     else:
                         job = q.enqueue(
                             task,
@@ -302,6 +309,15 @@ class split_job(job):
                     job.meta['requeue'] = self.requeue
                     job.save()
                     set_hash_job(job)
+                    if self.on_commit:
+                        ProcessJobs.add_job(transaction_id, job, q, at_front)
+                        log('Created split job (%s/%s) on queue %s in %s mode '
+                            '(id:%s): [%s] pool(%s).%s%s '
+                            '(waiting to commit/rollback %s)' % (
+                                idx + 1, len(chunks), q.name, mode, job.id,
+                                dbname, osv_object, fname, tuple(args[2:]),
+                                transaction_id
+                        ))
                     jobs.append(job)
                 return jobs
             else:

--- a/oorq/decorators.py
+++ b/oorq/decorators.py
@@ -7,6 +7,7 @@ import os
 
 from rq import Queue
 from rq.job import Job
+from rq.exceptions import NoSuchJobError
 from rq import get_current_job
 from .oorq import setup_redis_connection, set_hash_job, AsyncMode, get_redis_url
 from osconf import config_from_environment
@@ -27,7 +28,7 @@ from service.taskmanager import TaskManager
 current_task = TaskManager.current_task()
 
 
-JobToProcess = namedtuple('JobToProcess', ['job', 'queue', 'at_front'])
+JobToProcess = namedtuple('JobToProcess', ['job_id', 'queue_name', 'at_front'])
 
 
 class ProcessJobs(object):
@@ -38,7 +39,7 @@ class ProcessJobs(object):
     def add_job(cls, transaction_id, job, queue, at_font=False):
         cls.JOBS_TO_PROCESS.setdefault(transaction_id, [])
         cls.JOBS_TO_PROCESS[transaction_id].append(
-            JobToProcess(job, queue, at_font)
+            JobToProcess(job.id, queue.name, at_font)
         )
 
     @staticmethod
@@ -53,11 +54,14 @@ class ProcessJobs(object):
     @staticmethod
     def commit(cursor):
         transaction_id = id(cursor)
+        redis_conn = setup_redis_connection()
         jobs = [
             j for j in ProcessJobs.JOBS_TO_PROCESS.pop(transaction_id, [])
             if isinstance(j, JobToProcess)
         ]
-        for job, queue, at_front in jobs:
+        for job_id, queue_name, at_front in jobs:
+            job = Job.fetch(job_id, connection=redis_conn)
+            queue = Queue(queue_name, connection=redis_conn)
             queue.enqueue_job(job, at_front=at_front)
             log('Enqueued job {} to queue {} from commit transaction {}'.format(
                 job.id, queue.name, transaction_id
@@ -66,25 +70,39 @@ class ProcessJobs(object):
             del ProcessJobs.JOBS_TO_PROCESS[transaction_id]
 
     @staticmethod
+    def _delete_jobs(jobs):
+        redis_conn = setup_redis_connection()
+        for job_id, queue_name, at_front in jobs:
+            try:
+                Job.fetch(job_id, connection=redis_conn).delete()
+            except NoSuchJobError:
+                log('Job {} was already deleted before rollback cleanup'.format(
+                    job_id
+                ), netsvc.LOG_WARNING)
+
+    @staticmethod
     def rollback(cursor):
         transaction_id = id(cursor)
-        jobs = ProcessJobs.JOBS_TO_PROCESS.pop(transaction_id, [])
+        jobs = [
+            j for j in ProcessJobs.JOBS_TO_PROCESS.pop(transaction_id, [])
+            if isinstance(j, JobToProcess)
+        ]
         if jobs:
             log('Cancelling {} jobs from rollback of transaction {}'.format(
                 len(jobs), transaction_id
             ))
+            ProcessJobs._delete_jobs(jobs)
 
     @staticmethod
     def rollback_savepoint(cursor, savepoint):
         transaction_id = id(cursor)
         try:
             index = ProcessJobs.JOBS_TO_PROCESS[transaction_id].index(savepoint)
-            jobs = [
-                j for j in ProcessJobs.JOBS_TO_PROCESS[transaction_id][index:]
-                if isinstance(j, JobToProcess)
-            ]
+            rollback_items = ProcessJobs.JOBS_TO_PROCESS[transaction_id][index:]
+            jobs = [j for j in rollback_items if isinstance(j, JobToProcess)]
             log('Cancelling {} jobs from rollback to savepoint {} of '
                 'transaction {}'.format(len(jobs), savepoint, transaction_id))
+            ProcessJobs._delete_jobs(jobs)
             del ProcessJobs.JOBS_TO_PROCESS[transaction_id][index:]
         except ValueError:
             pass

--- a/oorq/requirements.txt
+++ b/oorq/requirements.txt
@@ -8,4 +8,5 @@ rq-dashboard
 osconf
 autoworker
 six
+pytz
 MarkupSafe<=2.0.1

--- a/oorq/tests/test_oorq/tests/__init__.py
+++ b/oorq/tests/test_oorq/tests/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import
 from .test_autoworkers import *
 from .test_oorq import *
 from .test_taskmanager import *
+from .test_process_jobs import *

--- a/oorq/tests/test_oorq/tests/test_process_jobs.py
+++ b/oorq/tests/test_oorq/tests/test_process_jobs.py
@@ -1,25 +1,6 @@
 # coding=utf-8
-import imp
-import os
-import sys
-import types
 import unittest
-
-
-class FakeLogger(object):
-    def notifyChannel(self, *args, **kwargs):
-        pass
-
-
-class FakeSignal(object):
-    def connect(self, callback):
-        pass
-
-
-class FakeTaskManager(object):
-    @staticmethod
-    def current_task():
-        return None
+from oorq import decorators
 
 
 class FakeNoSuchJobError(Exception):
@@ -59,114 +40,24 @@ class FakeQueue(object):
         self.enqueued.append((self.name, job.id, at_front, self.connection))
 
 
-def install_import_stubs():
-    oorq_package = types.ModuleType('oorq')
-    oorq_package.__path__ = []
-    sys.modules['oorq'] = oorq_package
-
-    oorq_module = types.ModuleType('oorq.oorq')
-    oorq_module.setup_redis_connection = lambda: 'redis-conn'
-    oorq_module.set_hash_job = lambda job: None
-    oorq_module.get_redis_url = lambda conn: 'redis://localhost:6379/0'
-
-    class FakeAsyncMode(object):
-        @staticmethod
-        def is_async():
-            return True
-
-    oorq_module.AsyncMode = FakeAsyncMode
-    sys.modules['oorq.oorq'] = oorq_module
-
-    exceptions = types.ModuleType('oorq.exceptions')
-    sys.modules['oorq.exceptions'] = exceptions
-
-    tasks = types.ModuleType('oorq.tasks')
-    tasks.make_chunks = lambda ids, n_chunks=None, size=None: [ids]
-    tasks.execute = lambda *args, **kwargs: None
-    tasks.isolated_execute = lambda *args, **kwargs: None
-    tasks.update_jobs_group = lambda *args, **kwargs: None
-    sys.modules['oorq.tasks'] = tasks
-
-    rq_module = types.ModuleType('rq')
-    rq_module.Queue = FakeQueue
-    rq_module.get_current_job = lambda: None
-    sys.modules['rq'] = rq_module
-
-    rq_job_module = types.ModuleType('rq.job')
-    rq_job_module.Job = FakeJob
-    sys.modules['rq.job'] = rq_job_module
-
-    rq_exceptions_module = types.ModuleType('rq.exceptions')
-
-    rq_exceptions_module.NoSuchJobError = FakeNoSuchJobError
-    sys.modules['rq.exceptions'] = rq_exceptions_module
-
-    osconf_module = types.ModuleType('osconf')
-    osconf_module.config_from_environment = lambda prefix, **kwargs: kwargs
-    sys.modules['osconf'] = osconf_module
-
-    if 'tools' not in sys.modules:
-        tools = types.ModuleType('tools')
-        tools.config = {'database': 'test'}
-        sys.modules['tools'] = tools
-    if 'netsvc' not in sys.modules:
-        netsvc = types.ModuleType('netsvc')
-        netsvc.LOG_INFO = 20
-        netsvc.LOG_WARNING = 30
-        netsvc.SERVICES = {}
-        netsvc.Logger = FakeLogger
-        sys.modules['netsvc'] = netsvc
-    if 'signals' not in sys.modules:
-        signals = types.ModuleType('signals')
-        signals.DB_CURSOR_COMMIT = FakeSignal()
-        signals.DB_CURSOR_ROLLBACK = FakeSignal()
-        signals.DB_CURSOR_ROLLBACK_SAVEPOINT = FakeSignal()
-        signals.DB_CURSOR_SAVEPOINT = FakeSignal()
-        sys.modules['signals'] = signals
-    if 'autoworker' not in sys.modules:
-        autoworker = types.ModuleType('autoworker')
-        autoworker.AutoWorker = object
-        sys.modules['autoworker'] = autoworker
-    if 'ctx' not in sys.modules:
-        ctx = types.ModuleType('ctx')
-        ctx.sudo = None
-        sys.modules['ctx'] = ctx
-    if 'service' not in sys.modules:
-        service = types.ModuleType('service')
-        sys.modules['service'] = service
-    if 'service.taskmanager' not in sys.modules:
-        taskmanager = types.ModuleType('service.taskmanager')
-        taskmanager.TaskManager = FakeTaskManager
-        sys.modules['service.taskmanager'] = taskmanager
-
-
-def load_decorators_module():
-    install_import_stubs()
-    decorators_path = os.path.abspath(os.path.join(
-        os.path.dirname(__file__), '..', '..', '..', 'decorators.py'
-    ))
-    if 'oorq.decorators' in sys.modules:
-        del sys.modules['oorq.decorators']
-    return imp.load_source('oorq.decorators', decorators_path)
-
-
 class FakeCursor(object):
     pass
 
 
-class TestProcessJobs(unittest.TestCase):
-    MODULES_TO_STUB = [
-        'oorq', 'oorq.decorators', 'oorq.oorq', 'oorq.exceptions',
-        'oorq.tasks', 'rq', 'rq.job', 'rq.exceptions', 'osconf',
-        'tools', 'netsvc', 'signals', 'autoworker', 'ctx', 'service',
-        'service.taskmanager'
-    ]
+_MISSING = object()
 
+
+class TestProcessJobs(unittest.TestCase):
     def setUp(self):
-        self.original_modules = dict(
-            (name, sys.modules.get(name)) for name in self.MODULES_TO_STUB
+        self.decorators = decorators
+        self.original_job = self.decorators.Job
+        self.original_queue = self.decorators.Queue
+        self.original_no_such_job_error = getattr(
+            self.decorators, 'NoSuchJobError', _MISSING
         )
-        self.decorators = load_decorators_module()
+        self.original_setup_redis_connection = (
+            self.decorators.setup_redis_connection
+        )
         self.decorators.ProcessJobs.JOBS_TO_PROCESS = {}
         FakeJob.deleted = []
         FakeJob.fetched = []
@@ -175,14 +66,23 @@ class TestProcessJobs(unittest.TestCase):
         FakeQueue.fail_on_job_ids = set()
         self.decorators.Job = FakeJob
         self.decorators.Queue = FakeQueue
+        self.decorators.NoSuchJobError = FakeNoSuchJobError
         self.decorators.setup_redis_connection = lambda: 'redis-conn'
 
     def tearDown(self):
-        for name, module in self.original_modules.items():
-            if module is None:
-                sys.modules.pop(name, None)
-            else:
-                sys.modules[name] = module
+        self.decorators.Job = self.original_job
+        self.decorators.Queue = self.original_queue
+        if self.original_no_such_job_error is _MISSING:
+            try:
+                del self.decorators.NoSuchJobError
+            except AttributeError:
+                pass
+        else:
+            self.decorators.NoSuchJobError = self.original_no_such_job_error
+        self.decorators.setup_redis_connection = (
+            self.original_setup_redis_connection
+        )
+        self.decorators.ProcessJobs.JOBS_TO_PROCESS = {}
 
     def test_add_job_keeps_minimal_reference_only(self):
         cursor = FakeCursor()

--- a/oorq/tests/test_oorq/tests/test_process_jobs.py
+++ b/oorq/tests/test_oorq/tests/test_process_jobs.py
@@ -22,9 +22,14 @@ class FakeTaskManager(object):
         return None
 
 
+class FakeNoSuchJobError(Exception):
+    pass
+
+
 class FakeJob(object):
     deleted = []
     fetched = []
+    missing_jobs = set()
 
     def __init__(self, job_id):
         self.id = job_id
@@ -32,6 +37,8 @@ class FakeJob(object):
     @classmethod
     def fetch(cls, job_id, connection=None):
         cls.fetched.append((job_id, connection))
+        if job_id in cls.missing_jobs:
+            raise FakeNoSuchJobError()
         return cls(job_id)
 
     def delete(self):
@@ -40,12 +47,15 @@ class FakeJob(object):
 
 class FakeQueue(object):
     enqueued = []
+    fail_on_job_ids = set()
 
     def __init__(self, name, connection=None, **kwargs):
         self.name = name
         self.connection = connection
 
     def enqueue_job(self, job, at_front=False):
+        if job.id in self.fail_on_job_ids:
+            raise RuntimeError('enqueue failed')
         self.enqueued.append((self.name, job.id, at_front, self.connection))
 
 
@@ -87,9 +97,6 @@ def install_import_stubs():
     sys.modules['rq.job'] = rq_job_module
 
     rq_exceptions_module = types.ModuleType('rq.exceptions')
-
-    class FakeNoSuchJobError(Exception):
-        pass
 
     rq_exceptions_module.NoSuchJobError = FakeNoSuchJobError
     sys.modules['rq.exceptions'] = rq_exceptions_module
@@ -135,9 +142,9 @@ def install_import_stubs():
 
 def load_decorators_module():
     install_import_stubs()
-    decorators_path = os.path.join(
-        os.path.dirname(os.path.dirname(__file__)), 'oorq', 'decorators.py'
-    )
+    decorators_path = os.path.abspath(os.path.join(
+        os.path.dirname(__file__), '..', '..', '..', 'decorators.py'
+    ))
     if 'oorq.decorators' in sys.modules:
         del sys.modules['oorq.decorators']
     return imp.load_source('oorq.decorators', decorators_path)
@@ -148,15 +155,34 @@ class FakeCursor(object):
 
 
 class TestProcessJobs(unittest.TestCase):
+    MODULES_TO_STUB = [
+        'oorq', 'oorq.decorators', 'oorq.oorq', 'oorq.exceptions',
+        'oorq.tasks', 'rq', 'rq.job', 'rq.exceptions', 'osconf',
+        'tools', 'netsvc', 'signals', 'autoworker', 'ctx', 'service',
+        'service.taskmanager'
+    ]
+
     def setUp(self):
+        self.original_modules = dict(
+            (name, sys.modules.get(name)) for name in self.MODULES_TO_STUB
+        )
         self.decorators = load_decorators_module()
         self.decorators.ProcessJobs.JOBS_TO_PROCESS = {}
         FakeJob.deleted = []
         FakeJob.fetched = []
+        FakeJob.missing_jobs = set()
         FakeQueue.enqueued = []
+        FakeQueue.fail_on_job_ids = set()
         self.decorators.Job = FakeJob
         self.decorators.Queue = FakeQueue
         self.decorators.setup_redis_connection = lambda: 'redis-conn'
+
+    def tearDown(self):
+        for name, module in self.original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
 
     def test_add_job_keeps_minimal_reference_only(self):
         cursor = FakeCursor()
@@ -184,6 +210,41 @@ class TestProcessJobs(unittest.TestCase):
         self.assertEqual(FakeJob.fetched, [('job-1', 'redis-conn')])
         self.assertEqual(FakeQueue.enqueued, [('queue-1', 'job-1', False, 'redis-conn')])
         self.assertNotIn(id(cursor), self.decorators.ProcessJobs.JOBS_TO_PROCESS)
+
+    def test_commit_skips_missing_jobs(self):
+        cursor = FakeCursor()
+        FakeJob.missing_jobs = set(['job-missing'])
+        self.decorators.ProcessJobs.add_job(
+            id(cursor), FakeJob('job-missing'), FakeQueue('queue-1'), False
+        )
+        self.decorators.ProcessJobs.add_job(
+            id(cursor), FakeJob('job-ok'), FakeQueue('queue-1'), False
+        )
+
+        self.decorators.ProcessJobs.commit(cursor)
+
+        self.assertEqual(FakeQueue.enqueued, [('queue-1', 'job-ok', False, 'redis-conn')])
+        self.assertNotIn(id(cursor), self.decorators.ProcessJobs.JOBS_TO_PROCESS)
+
+    def test_commit_keeps_pending_jobs_if_enqueue_fails(self):
+        cursor = FakeCursor()
+        FakeQueue.fail_on_job_ids = set(['job-2'])
+        self.decorators.ProcessJobs.add_job(
+            id(cursor), FakeJob('job-1'), FakeQueue('queue-1'), False
+        )
+        self.decorators.ProcessJobs.add_job(
+            id(cursor), FakeJob('job-2'), FakeQueue('queue-1'), False
+        )
+        self.decorators.ProcessJobs.add_job(
+            id(cursor), FakeJob('job-3'), FakeQueue('queue-1'), False
+        )
+
+        with self.assertRaises(RuntimeError):
+            self.decorators.ProcessJobs.commit(cursor)
+
+        self.assertEqual(FakeQueue.enqueued, [('queue-1', 'job-1', False, 'redis-conn')])
+        pending = self.decorators.ProcessJobs.JOBS_TO_PROCESS[id(cursor)]
+        self.assertEqual([job.job_id for job in pending], ['job-2', 'job-3'])
 
     def test_rollback_deletes_pending_jobs_from_redis(self):
         cursor = FakeCursor()

--- a/tests/test_process_jobs.py
+++ b/tests/test_process_jobs.py
@@ -1,0 +1,222 @@
+# coding=utf-8
+import imp
+import os
+import sys
+import types
+import unittest
+
+
+class FakeLogger(object):
+    def notifyChannel(self, *args, **kwargs):
+        pass
+
+
+class FakeSignal(object):
+    def connect(self, callback):
+        pass
+
+
+class FakeTaskManager(object):
+    @staticmethod
+    def current_task():
+        return None
+
+
+class FakeJob(object):
+    deleted = []
+    fetched = []
+
+    def __init__(self, job_id):
+        self.id = job_id
+
+    @classmethod
+    def fetch(cls, job_id, connection=None):
+        cls.fetched.append((job_id, connection))
+        return cls(job_id)
+
+    def delete(self):
+        self.deleted.append(self.id)
+
+
+class FakeQueue(object):
+    enqueued = []
+
+    def __init__(self, name, connection=None, **kwargs):
+        self.name = name
+        self.connection = connection
+
+    def enqueue_job(self, job, at_front=False):
+        self.enqueued.append((self.name, job.id, at_front, self.connection))
+
+
+def install_import_stubs():
+    oorq_package = types.ModuleType('oorq')
+    oorq_package.__path__ = []
+    sys.modules['oorq'] = oorq_package
+
+    oorq_module = types.ModuleType('oorq.oorq')
+    oorq_module.setup_redis_connection = lambda: 'redis-conn'
+    oorq_module.set_hash_job = lambda job: None
+    oorq_module.get_redis_url = lambda conn: 'redis://localhost:6379/0'
+
+    class FakeAsyncMode(object):
+        @staticmethod
+        def is_async():
+            return True
+
+    oorq_module.AsyncMode = FakeAsyncMode
+    sys.modules['oorq.oorq'] = oorq_module
+
+    exceptions = types.ModuleType('oorq.exceptions')
+    sys.modules['oorq.exceptions'] = exceptions
+
+    tasks = types.ModuleType('oorq.tasks')
+    tasks.make_chunks = lambda ids, n_chunks=None, size=None: [ids]
+    tasks.execute = lambda *args, **kwargs: None
+    tasks.isolated_execute = lambda *args, **kwargs: None
+    tasks.update_jobs_group = lambda *args, **kwargs: None
+    sys.modules['oorq.tasks'] = tasks
+
+    rq_module = types.ModuleType('rq')
+    rq_module.Queue = FakeQueue
+    rq_module.get_current_job = lambda: None
+    sys.modules['rq'] = rq_module
+
+    rq_job_module = types.ModuleType('rq.job')
+    rq_job_module.Job = FakeJob
+    sys.modules['rq.job'] = rq_job_module
+
+    rq_exceptions_module = types.ModuleType('rq.exceptions')
+
+    class FakeNoSuchJobError(Exception):
+        pass
+
+    rq_exceptions_module.NoSuchJobError = FakeNoSuchJobError
+    sys.modules['rq.exceptions'] = rq_exceptions_module
+
+    osconf_module = types.ModuleType('osconf')
+    osconf_module.config_from_environment = lambda prefix, **kwargs: kwargs
+    sys.modules['osconf'] = osconf_module
+
+    if 'tools' not in sys.modules:
+        tools = types.ModuleType('tools')
+        tools.config = {'database': 'test'}
+        sys.modules['tools'] = tools
+    if 'netsvc' not in sys.modules:
+        netsvc = types.ModuleType('netsvc')
+        netsvc.LOG_INFO = 20
+        netsvc.LOG_WARNING = 30
+        netsvc.SERVICES = {}
+        netsvc.Logger = FakeLogger
+        sys.modules['netsvc'] = netsvc
+    if 'signals' not in sys.modules:
+        signals = types.ModuleType('signals')
+        signals.DB_CURSOR_COMMIT = FakeSignal()
+        signals.DB_CURSOR_ROLLBACK = FakeSignal()
+        signals.DB_CURSOR_ROLLBACK_SAVEPOINT = FakeSignal()
+        signals.DB_CURSOR_SAVEPOINT = FakeSignal()
+        sys.modules['signals'] = signals
+    if 'autoworker' not in sys.modules:
+        autoworker = types.ModuleType('autoworker')
+        autoworker.AutoWorker = object
+        sys.modules['autoworker'] = autoworker
+    if 'ctx' not in sys.modules:
+        ctx = types.ModuleType('ctx')
+        ctx.sudo = None
+        sys.modules['ctx'] = ctx
+    if 'service' not in sys.modules:
+        service = types.ModuleType('service')
+        sys.modules['service'] = service
+    if 'service.taskmanager' not in sys.modules:
+        taskmanager = types.ModuleType('service.taskmanager')
+        taskmanager.TaskManager = FakeTaskManager
+        sys.modules['service.taskmanager'] = taskmanager
+
+
+def load_decorators_module():
+    install_import_stubs()
+    decorators_path = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), 'oorq', 'decorators.py'
+    )
+    if 'oorq.decorators' in sys.modules:
+        del sys.modules['oorq.decorators']
+    return imp.load_source('oorq.decorators', decorators_path)
+
+
+class FakeCursor(object):
+    pass
+
+
+class TestProcessJobs(unittest.TestCase):
+    def setUp(self):
+        self.decorators = load_decorators_module()
+        self.decorators.ProcessJobs.JOBS_TO_PROCESS = {}
+        FakeJob.deleted = []
+        FakeJob.fetched = []
+        FakeQueue.enqueued = []
+        self.decorators.Job = FakeJob
+        self.decorators.Queue = FakeQueue
+        self.decorators.setup_redis_connection = lambda: 'redis-conn'
+
+    def test_add_job_keeps_minimal_reference_only(self):
+        cursor = FakeCursor()
+        job = FakeJob('job-1')
+        queue = FakeQueue('queue-1', connection='original-conn')
+
+        self.decorators.ProcessJobs.add_job(id(cursor), job, queue, True)
+
+        pending = self.decorators.ProcessJobs.JOBS_TO_PROCESS[id(cursor)]
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(pending[0].job_id, 'job-1')
+        self.assertEqual(pending[0].queue_name, 'queue-1')
+        self.assertTrue(pending[0].at_front)
+        self.assertFalse(hasattr(pending[0], 'job'))
+        self.assertFalse(hasattr(pending[0], 'queue'))
+
+    def test_commit_fetches_job_and_queue_from_redis(self):
+        cursor = FakeCursor()
+        self.decorators.ProcessJobs.add_job(
+            id(cursor), FakeJob('job-1'), FakeQueue('queue-1'), False
+        )
+
+        self.decorators.ProcessJobs.commit(cursor)
+
+        self.assertEqual(FakeJob.fetched, [('job-1', 'redis-conn')])
+        self.assertEqual(FakeQueue.enqueued, [('queue-1', 'job-1', False, 'redis-conn')])
+        self.assertNotIn(id(cursor), self.decorators.ProcessJobs.JOBS_TO_PROCESS)
+
+    def test_rollback_deletes_pending_jobs_from_redis(self):
+        cursor = FakeCursor()
+        self.decorators.ProcessJobs.add_job(
+            id(cursor), FakeJob('job-1'), FakeQueue('queue-1'), False
+        )
+        self.decorators.ProcessJobs.add_job(
+            id(cursor), FakeJob('job-2'), FakeQueue('queue-1'), True
+        )
+
+        self.decorators.ProcessJobs.rollback(cursor)
+
+        self.assertEqual(FakeJob.deleted, ['job-1', 'job-2'])
+        self.assertEqual(FakeQueue.enqueued, [])
+        self.assertNotIn(id(cursor), self.decorators.ProcessJobs.JOBS_TO_PROCESS)
+
+    def test_rollback_savepoint_deletes_discarded_jobs_only(self):
+        cursor = FakeCursor()
+        self.decorators.ProcessJobs.add_job(
+            id(cursor), FakeJob('job-before'), FakeQueue('queue-1'), False
+        )
+        self.decorators.ProcessJobs.savepoint(cursor, 'sp1')
+        self.decorators.ProcessJobs.add_job(
+            id(cursor), FakeJob('job-after'), FakeQueue('queue-1'), False
+        )
+
+        self.decorators.ProcessJobs.rollback_savepoint(cursor, 'sp1')
+
+        self.assertEqual(FakeJob.deleted, ['job-after'])
+        pending = self.decorators.ProcessJobs.JOBS_TO_PROCESS[id(cursor)]
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(pending[0].job_id, 'job-before')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Objetivo

Reducir el consumo de RAM de los jobs `on_commit=True` manteniendo la semántica transaccional actual.

## Cambios

- `ProcessJobs` deja de retener instancias completas `rq.Job` y `Queue` en memoria.
- Los jobs pendientes de commit guardan solo:
  - `job_id`
  - `queue_name`
  - `at_front`
- En `commit`, se recupera el `Job` desde Redis y se reconstruye la `Queue` antes de encolar.
- En `rollback`, se eliminan de Redis los jobs pendientes que ya se habían guardado pero no enqueued.
- En `rollback_savepoint`, se eliminan solo los jobs descartados por el savepoint.
- Se añaden tests unitarios de `ProcessJobs` para commit, rollback, savepoint y contrato de referencia mínima.

## Fuera de alcance

- No implementa la fase 4 / outbox transaccional persistente.
- No cambia la semántica de `on_commit=True`.
- No cambia el formato/payload del job guardado en Redis.

## Validación local

- `py_compile` Py2/Py3 sobre `oorq/decorators.py` y `tests/test_process_jobs.py`.
- `tests/test_process_jobs.py` ejecutado con Python 2.7: 4 tests OK.
- `tests/test_process_jobs.py` ejecutado con Python 3: 4 tests OK.

## Relacionado

- Refs #134
