### PR TITLE
fix: limit redis dependency on python 3

### DIFF
--- a/oorq/requirements.txt
+++ b/oorq/requirements.txt
@@ -9,3 +9,4 @@ osconf
 autoworker
 six
 MarkupSafe<=2.0.1
+pytz

--- a/oorq/requirements.txt
+++ b/oorq/requirements.txt
@@ -1,7 +1,7 @@
 rq==1.3.0;python_version<="2.7.18"
 rq==1.16.2;python_version>"2.7.18"
 redis<3.6;python_version<="2.7.18"
-redis>=5.1.1;python_version>"2.7.18"
+redis>=5.1.1,<8.0.0;python_version>"2.7.18"
 rq-scheduler==0.11.0;python_version<="2.7.18"
 rq-scheduler>=0.13.1;python_version>"2.7.18"
 rq-dashboard


### PR DESCRIPTION
## Summary

- Limit the Python 3 `redis` dependency to `<8.0.0`.
- Keep the Python 2 dependency unchanged.
- Declare `pytz` as a runtime dependency because `oorq.oorq` imports it directly.

## Validation

- Parsed `oorq/requirements.txt` with `pkg_resources.Requirement.parse`.
- Installed `oorq/requirements.txt` in a temporary Python 3.11 venv and imported `pytz`, `redis`, and `rq` successfully.
- Attempted local `pytest tests -q`; collection is blocked by the existing legacy `rq.compat` import in `tests/__init__.py`, which is independent from this dependency fix and not the PR CI path.
