### PR TITLE
Fix on_commit jobs in sync mode

### DIFF
--- a/oorq/decorators.py
+++ b/oorq/decorators.py
@@ -147,7 +147,7 @@ class job(object):
                     }
                 if current_task and current_task.defer_exit:
                     job_kwargs['current_task_id'] = current_task.id
-                if self.on_commit and async_mode:
+                if self.on_commit:
                     job = Job.create(
                         execute,
                         args=job_args,

--- a/oorq/tests/test_oorq/tests/test_oorq.py
+++ b/oorq/tests/test_oorq/tests/test_oorq.py
@@ -232,3 +232,37 @@ class TestOORQAsync(TestOORQ):
                                    ['active'])
         self.assertEqual(len(res), 6)
         self.assertTrue(all(r['active'] for r in res))
+
+
+class TestOORQSyncOnCommit(TestOORQ):
+    @classmethod
+    def setUpClass(cls):
+        super(TestOORQ, cls).setUpClass()
+        cls.ori_oorq_async = os.environ.get('OORQ_ASYNC', 'True')
+        os.environ['OORQ_ASYNC'] = 'False'
+
+    @classmethod
+    def tearDownClass(cls):
+        os.environ['OORQ_ASYNC'] = cls.ori_oorq_async
+        super(TestOORQ, cls).tearDownClass()
+
+    def test_write_sync_on_commit_waits_for_commit(self):
+        partner_obj = self.openerp.pool.get('res.partner')
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            partner_obj.test_write_async(cursor, uid, self.new_partner_ids,
+                                         {'active': True})
+            res = partner_obj.read(cursor, uid, self.new_partner_ids,
+                                   ['active'])
+            self.assertEqual(len(res), 6)
+            self.assertTrue(all(not r['active'] for r in res))
+            cursor.commit()
+
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            res = partner_obj.read(cursor, uid, self.new_partner_ids,
+                                   ['active'])
+        self.assertEqual(len(res), 6)
+        self.assertTrue(all(r['active'] for r in res))


### PR DESCRIPTION
## Resumen

- Respeta `on_commit=True` también cuando `OORQ_ASYNC=False`.
- Añade una regresión que comprueba que el job síncrono no se ejecuta antes del `commit()` y sí después.

## Contexto

Con `OORQ_ASYNC=False`, `Queue(..., is_async=False).enqueue(...)` ejecuta el job inmediatamente. Hasta ahora `@job(on_commit=True)` solo difería el enqueue si `async_mode` era true, así que el modo síncrono ignoraba la semántica transaccional.

La solución reutiliza el mecanismo existente de `ProcessJobs` conectado a `DB_CURSOR_COMMIT/ROLLBACK`: si `on_commit=True`, el job se registra siempre y se encola en el commit. En modo síncrono, RQ lo ejecuta entonces, no antes.

## Validación

- RED confirmado antes del cambio: `TestOORQSyncOnCommit.test_write_sync_on_commit_waits_for_commit` fallaba porque el `read` previo al `commit()` ya veía `active=True`.
- GREEN después del cambio:
  - `destral -m test_oorq -t test_oorq.TestOORQSyncOnCommit.test_write_sync_on_commit_waits_for_commit -d test_7cd760f88b45457c8344eb3c95106970 --no-dropdb --no-requirements`
- `python -m py_compile oorq/decorators.py oorq/tests/test_oorq/tests/test_oorq.py` en Python 2.7 y Python 3.11.
- `git diff --check`.

Nota: la suite completa local `destral -m test_oorq` queda afectada por flakiness/estado local de workers Redis en tests preexistentes (`split_job` y `TaskManager`). No he cambiado esos caminos en esta PR.

## Relacionado

- Origen de la tarea: TASK-85718
