### PR TITLE
Propagar el selector global de consultas a los workers de OORQ

### DIFF
--- a/oorq/tasks.py
+++ b/oorq/tasks.py
@@ -58,6 +58,14 @@ def make_chunks(ids, n_chunks=None, size=None):
     return [ids[x:x + size] for x in range(0, len(ids), size)]
 
 
+def _webservice_tracker_kwargs(conf_attrs, **kwargs):
+    """Propagate the server query engine snapshot to worker trackers."""
+    query_engine = conf_attrs.get('global_query_engine', False)
+    if query_engine:
+        kwargs['ooquery_strategy'] = query_engine
+    return kwargs
+
+
 def execute(conf_attrs, dbname, uid, obj, method, *args, **kw):
     start = datetime.now()
     # Disabling logging in OpenERP
@@ -113,7 +121,11 @@ def execute(conf_attrs, dbname, uid, obj, method, *args, **kw):
     with context:
         with SimpleGlobalUUIDGenerator() as _uuid:
             _uuid = _uuid if not isinstance(_uuid, DummySudo) else None
-            with WebServiceTracker(_uuid=_uuid, uid=uid, obj=obj, method=method, db=db):
+            tracker_kwargs = _webservice_tracker_kwargs(
+                conf_attrs, _uuid=_uuid, uid=uid, obj=obj,
+                method=method, db=db,
+            )
+            with WebServiceTracker(**tracker_kwargs):
                 task_pushed = False
                 if 'current_task_id' in kw:
                     task_id = kw.pop('current_task_id')
@@ -179,7 +191,11 @@ def isolated_execute(conf_attrs, dbname, uid, obj, method, *args, **kw):
             with context:
                 with SimpleGlobalUUIDGenerator() as _uuid:
                     _uuid = _uuid if not isinstance(_uuid, DummySudo) else None
-                    with WebServiceTracker(_uuid=_uuid, uid=uid, obj=obj, method=method):
+                    tracker_kwargs = _webservice_tracker_kwargs(
+                        conf_attrs, _uuid=_uuid, uid=uid, obj=obj,
+                        method=method,
+                    )
+                    with WebServiceTracker(**tracker_kwargs):
                         task_pushed = False
                         if 'current_task_id' in kw:
                             task_id = kw.pop('current_task_id')
@@ -250,7 +266,11 @@ def report(conf_attrs, dbname, uid, obj, ids, datas=None, context=None):
         datas['model'] = getattr(obj._service, 'table', False) or getattr(obj._service, 'model', False)
     with SimpleGlobalUUIDGenerator() as _uuid:
         _uuid = _uuid if not isinstance(_uuid, DummySudo) else None
-        with WebServiceTracker(_uuid=_uuid, uid=uid, obj=_obj_name, method='report', db=conn) as wst:
+        tracker_kwargs = _webservice_tracker_kwargs(
+            conf_attrs, _uuid=_uuid, uid=uid, obj=_obj_name,
+            method='report', db=conn,
+        )
+        with WebServiceTracker(**tracker_kwargs) as wst:
             with SentryCatch(_uuid=_uuid, obj=_obj_name, method='report'):
                 result, format = obj.create(cursor, uid, ids, datas, context)
     job.meta['format'] = format

--- a/oorq/tests/test_oorq/tests/__init__.py
+++ b/oorq/tests/test_oorq/tests/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import
 from .test_autoworkers import *
 from .test_oorq import *
 from .test_taskmanager import *
+from .test_tracker_config import *

--- a/oorq/tests/test_oorq/tests/test_tracker_config.py
+++ b/oorq/tests/test_oorq/tests/test_tracker_config.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import
+
+from destral import testing
+
+
+class TestTrackerConfig(testing.OOTestCaseWithCursor):
+    def test_global_query_engine_is_forwarded_to_worker_tracker(self):
+        from oorq.tasks import _webservice_tracker_kwargs
+
+        kwargs = _webservice_tracker_kwargs(
+            {'global_query_engine': 'auto'}, uid=1, obj='res.users'
+        )
+
+        self.assertEqual(kwargs['ooquery_strategy'], 'auto')
+        self.assertEqual(kwargs['uid'], 1)
+        self.assertEqual(kwargs['obj'], 'res.users')
+
+    def test_disabled_global_query_engine_is_not_forwarded(self):
+        from oorq.tasks import _webservice_tracker_kwargs
+
+        kwargs = _webservice_tracker_kwargs(
+            {'global_query_engine': False}, uid=1
+        )
+
+        self.assertNotIn('ooquery_strategy', kwargs)


### PR DESCRIPTION
## Objetivos

- Propagar el valor de `global_query_engine` capturado al encolar un trabajo a los trackers de los workers.
- Mantener la misma estrategia en ejecuciones normales, ejecuciones aisladas y generación de informes.

## Comportamiento

El worker conserva el snapshot de configuración recibido en `conf_attrs` y pasa `ooquery_strategy` explícitamente a `WebServiceTracker` cuando el selector global está activo. Si la configuración está desactivada, el tracker conserva su comportamiento anterior.

## Dependencias

- Depende de gisce/erp#28923, que valida `global_query_engine` y aplica el default compartido a RPC, REST, crons y workflows.

## Validación

- Python 2.7: `TestTrackerConfig`, 2/2 tests OK con Destral.
- Python 3.11: `TestTrackerConfig`, 2/2 tests OK con Destral.
- Sintaxis de `oorq/tasks.py` y de los tests validada en ambos runtimes.

## Relacionado

- TASK-93748
- gisce/erp#28923

Requested by: @polsala
